### PR TITLE
Additional features to improve flexibility of port selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+go.sum
 .idea/
 jack-peak-meter

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module jack-peak-meter
 
 go 1.12
 
-require github.com/xthexder/go-jack v0.0.0-20180616204541-62cc22fa20b6 // indirect
+require github.com/xthexder/go-jack v0.0.0-20180616204541-62cc22fa20b6


### PR DESCRIPTION
Added support for -port parameter, which allows you to specify one
or more port name matches (regular expressions). The original behavior
is preserved by making the default "system:(capture|monitor)_"

Added support for an -offset parameter, which allows you to skip the
first N ports that match. This is helpful if you have a lot of channels
and want to iterate over them with the command line, for example to
find where a buzzing microphone is coming from.

Added support for a -names parameter, which similar to -index will
display the name of each port. This makes it a lot easier to identify
what audio you are monitoring.

Added support for a -verbose parameter, which currently just displays
a message indicating which ports it is monitoring.